### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Vision_Sensor/keywords.txt
+++ b/Vision_Sensor/keywords.txt
@@ -3,7 +3,7 @@ begin	KEYWORD2
 read	KEYWORD2
 routine	KEYWORD2
 valid	KEYWORD2
-getWidth KEYWORD2
+getWidth	KEYWORD2
 getY	KEYWORD2
 getX	KEYWORD2
-getHeight KEYWORD2
+getHeight	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords